### PR TITLE
Fix: Spring Boot 버전 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'PhishingUniv'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = '11'
 
 configurations {
 	compileOnly {


### PR DESCRIPTION
프로젝트에서 JDK11을 사용하므로 Spring Boot 버전을 3.0.2에서 2.7.6으로  수정
- Spring Boot 3.x.x 버전은 JDK17 사용
- Spring Boot 2.x.x 버전은 JDK11 사용
